### PR TITLE
version 1.7

### DIFF
--- a/library.py
+++ b/library.py
@@ -2,9 +2,9 @@
 """
 Generate COVID19 CanCOGen Metadata Function Library
 
-Version: 1.6
+Version: 1.7
 COVID-19 Vocab Version #39
-Date: 2020/06/10
+Date: 2020/06/11
 
 Python v 3.8.3
 
@@ -19,6 +19,10 @@ import datetime
 import string
 import uuid
 from num2words import num2words
+
+
+# Error grid output indicating valid data
+global_valid_data = '-'
 
 
 def generate_covid19_dict(covid19_vocab):
@@ -74,17 +78,17 @@ def generate_covid19_vars():
 
 
 # PHAC sample ID
-def random_phac_id():
+def random_phac_id(invalid_data):
   """
   Generate Random PHAC ID
   
   return: string formatted to imitate a PHAC sample ID.
   """
-  return ("PHAC_" + str(random.randint(99, 2001)))
+  return ("PHAC_" + str(random.randint(99, 2001))), global_valid_data
 
 
 # umbrella bioproject accession
-def umbrella_bioproject_accession():
+def umbrella_bioproject_accession(invalid_data):
   """
   Umbrella BioProject Accession
   
@@ -92,44 +96,44 @@ def umbrella_bioproject_accession():
           Different provinces will have their own BioProjects, however these 
           BioProjects will be linked under one umbrella BioProject.
   """
-  return ("PRJNA623807")
+  return ("PRJNA623807"), global_valid_data
 
 
 # bioproject accession
-def random_bioproject_accession():
+def random_bioproject_accession(invalid_data):
   """
   Generate Random BioProject Accession
   
   return: string formatted to imitate a bioproject accession number. A valid 
           NCBI BioProject accession has prefix PRJNA, followed by six numerals.
   """
-  return ("PRJNA" + str(random.randint(400000,1000000)))
+  return ("PRJNA" + str(random.randint(400000,1000000))), global_valid_data
 
 
 # biosample accession
-def random_biosample_accession():
+def random_biosample_accession(invalid_data):
   """
   Generate Random BioSample Accession
   
   return: string formatted to imitate a biosample accession number. NCBI 
           BioSamples will have the prefix SAMN.
   """
-  return ("SAMN" + str(random.randint(10000000,20000001)))
+  return ("SAMN" + str(random.randint(10000000,20000001))), global_valid_data
 
 
 # SRA accession
-def random_sra_accession():
+def random_sra_accession(invalid_data):
   """
   Generate Random SRA Accession
   
   return: string formatted to imitate a SRA accession. NCBI-SRA accessions 
           start with SRR.
   """
-  return ("SRR" + str(random.randint(10000000,90000001)))
+  return ("SRR" + str(random.randint(10000000,90000001))), global_valid_data
 
 
 # GenBank accession
-def random_genbank_accession():
+def random_genbank_accession(invalid_data):
   """
   Generate Random GenBank Accession
   
@@ -142,11 +146,12 @@ def random_genbank_accession():
             'KP', 'KR', 'KT', 'KU', 'KX', 'KY', 'MF', 'MG', 'MH', 'MK', 'MN', 
             'MT']
   # suffix is 6 numerals.
-  return (random.choice(prefix) + str(random.randint(100000,1000000)))
+  return ((random.choice(prefix) + str(random.randint(100000,1000000))), 
+          global_valid_data)
 
 
 # GISAID accession
-def random_gisaid_accession():
+def random_gisaid_accession(invalid_data):
   """
   Generate Random GISAID Accession
   
@@ -154,11 +159,11 @@ def random_gisaid_accession():
           submission. GISAID currently uses the prefix "EPI_ISL_" for 
           SARS-CoV-2 submissions.
   """
-  return ("EPI_ISL_" + str(random.randint(400000,600000)))
+  return ("EPI_ISL_" + str(random.randint(400000,600000))), global_valid_data
 
 
 # reference genome accession
-def random_ref_genome():
+def random_ref_genome(invalid_data):
   """
   Generate Random Genome Accession 
   
@@ -167,52 +172,61 @@ def random_ref_genome():
   """
   # choose from list of commonly used SARS-CoV-2 reference genomes.
   real = random.choice(covid19_vocab_dict.get('reference_genome_accession'))
-  # choose from random accession formats defined in library.
-  fake = random.choice([random_genbank_accession(), random_sra_accession(), 
-                        random_biosample_accession(), random_gisaid_accession()])
-  return random.choice([real, fake])
+  # choose from random accession formats defined in library, 
+  # omitting data validity information.
+  fake = random.choice([random_genbank_accession(invalid_data)[0], 
+                        random_sra_accession(invalid_data)[0], 
+                        random_biosample_accession(invalid_data)[0], 
+                        random_gisaid_accession(invalid_data)[0]])
+  
+  return random.choice([real, fake]), global_valid_data
 
 
 # sample collected by
 # sequence submitter by
-def random_agency():
+def random_agency(invalid_data):
   """
   Generate Random Sample Collection Agency
   
   return: string referencing a Canadian Public Health agency.
   """
   agency = random.choice(covid19_vocab_dict.get('agencies'))
-  return agency
+  
+  return agency, global_valid_data
 
 
 Faker('en_GB').name()
 # sample collector contact email
 # sequence submitter contact email
-def random_email():
+def random_email(invalid_data):
   """
   Generate Random E-mail
   
   return: string containing imitation email address from random domains.
   """
-  return random.choice([Faker().email(), Faker().company_email()])
+  
+  return (random.choice([Faker().email(), Faker().company_email()]), 
+          global_valid_data)
 
 
 # sample collector contact address
 # sequence submitter contact address
-def random_address():
+def random_address(invalid_data):
   """
   Generate Random Address
   
   return: string containing imitation postal address.
   """
   fake = Faker(['en_CA']) # localized to Canada
-  return fake.address().replace('\n',', ')
+  
+  return fake.address().replace('\n',', '), global_valid_data
 
 
 # sample collection date
 # sample received date
 # symptom onset date
-def random_date(error=False):
+def random_date(invalid_data):
+#def random_date(invalid_data):
   """
   Generate Random Date
   
@@ -229,7 +243,7 @@ def random_date(error=False):
   date = Faker().date_between(start_date, end_date='today')
   
   # output invalid date format.
-  if error:
+  if 'date_error' in invalid_data:
    
     while True:
                  
@@ -258,137 +272,148 @@ def random_date(error=False):
   # output valid ISO 8601 standard date format.
   else:
     # return date in YYYY-MM-DD.
-    return random.choice([date])
+    return random.choice([date]), global_valid_data
 
 
 # geo_loc_name_country
 # host origin geo_loc name (country)
 # location of exposure geo_loc name (country)
-def random_country():
+def random_country(invalid_data):
   """
   Generate Random Country
   
   return: string containing country name from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('geo_loc_name_country'))
+  return (random.choice(covid19_vocab_dict.get('geo_loc_name_country')), 
+          global_valid_data)
 
 
 # geo_loc_name_province/territory
-def random_province_territory():
+def random_province_territory(invalid_data):
   """
   Generate Random Canadian Province/Territory
   
   return: string containing province/territory name from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('geo_loc_name_province_territory'))
+  return (random.choice(covid19_vocab_dict.get('geo_loc_name_province_territory')), 
+          global_valid_data)
 
 
 # geo_loc_name_city
-def random_city():
+def random_city(invalid_data):
   """
   Generate Random Canadian City
   
   return: string containing city name.
   """
   fake = Faker(['en_CA']) # localized to Canada
-  return fake.city()
+  
+  return fake.city(), global_valid_data
 
 
 # organism
-def random_organism():
+def random_organism(invalid_data):
   """
   Generate Random Organism
   
   return: string containing "organism" name from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('organism'))
+  return random.choice(covid19_vocab_dict.get('organism')), global_valid_data
 
 
 # purpose of sampling
-def random_purpose_of_sampling():
+def random_purpose_of_sampling(invalid_data):
   """
   Generate Random Purpose of Sampling
   
   return: string containing "purpose of sampling" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('purpose_of_sampling'))
+  return (random.choice(covid19_vocab_dict.get('purpose_of_sampling')), 
+          global_valid_data)
 
 
 # anatomical material
-def random_anatomical_material():
+def random_anatomical_material(invalid_data):
   """
   Generate Random Anatomical Material
   
   return: string containing "anatomical material" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('anatomical_material'))
+  return (random.choice(covid19_vocab_dict.get('anatomical_material')), 
+          global_valid_data)
 
 
 # anatomical part
-def random_anatomical_part():
+def random_anatomical_part(invalid_data):
   """
   Generate Random Anatomical Part
   
   return: string containing "anatomical part" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('anatomical_part'))
+  return (random.choice(covid19_vocab_dict.get('anatomical_part')), 
+          global_valid_data)
 
 
 # body product
-def random_body_product():
+def random_body_product(invalid_data):
   """
   Generate Random Body Product
   
   return: string containing "body part" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('body_product'))
+  return (random.choice(covid19_vocab_dict.get('body_product')), 
+          global_valid_data)
 
 
 # environmental material
-def random_environmental_material():
+def random_environmental_material(invalid_data):
   """
   Generate Random Environmental Material
   
   return: string containing "environmental material" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('environmental_material'))
+  return (random.choice(covid19_vocab_dict.get('environmental_material')), 
+          global_valid_data)
 
 
 # environmental site
-def random_environmental_site():
+def random_environmental_site(invalid_data):
   """
   Generate Random Environmental Site
   
   return: string containing "environmental site" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('environmental_site'))
+  return (random.choice(covid19_vocab_dict.get('environmental_site')), 
+          global_valid_data)
 
 
 # collection device
-def random_collection_device():
+def random_collection_device(invalid_data):
   """
   Generate Random Collection Device
   
   return: string containing "collection device" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('collection_device'))
+  return (random.choice(covid19_vocab_dict.get('collection_device')), 
+          global_valid_data)
 
 
 # collection method 
-def random_collection_method():
+def random_collection_method(invalid_data):
   """
   Generate Random Collection Device
   
   return: string containing "collection device" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('collection_method'))
+  return (random.choice(covid19_vocab_dict.get('collection_method')), 
+          global_valid_data)
 
 
 # collection protocol
 # sequencing_protocol_name
 # diagnostic_pcr_protocol 1
 # diagnostic_pcr_protocol 2
-def fake_protocol():
+def fake_protocol(invalid_data):
   """
   Generate Fake Protocol Name
   
@@ -401,31 +426,31 @@ def fake_protocol():
            random.choice(['',' ','_']))
   suffix = str(Faker().random_int(1,11))
 
-  return prefix + affix + suffix
-
+  return (prefix + affix + suffix), global_valid_data
 
 # specimen processing
-def random_specimen_processing():
+def random_specimen_processing(invalid_data):
   """
   Generate Random Specimen Processing
   
   return: string containing "specimen processing" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('specimen_processing'))
+  return (random.choice(covid19_vocab_dict.get('specimen_processing')), 
+          global_valid_data)
 
 
 # lab_host
-def random_lab_host():
+def random_lab_host(invalid_data):
   """
   Generate Random Lab Host Cell Line
   
   return: string containing "lab host" cell line from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('lab_host'))
+  return random.choice(covid19_vocab_dict.get('lab_host')), global_valid_data
 
 
 # passage number
-def random_passage_number():
+def random_passage_number(invalid_data):
   """
   Generate Random Viral Passage Number
   
@@ -434,11 +459,12 @@ def random_passage_number():
   passage = Faker().random_int(0,25) # maximum can be increased.
   if passage == 0:
     passage = 'not applicable'
-  return passage
+    
+  return passage, global_valid_data
 
 
 # passage method
-def passage_method_text():
+def passage_method_text(invalid_data):
   """
   Generate Viral Passage Method Name
   
@@ -446,69 +472,76 @@ def passage_method_text():
   """
   words = random.randint(2,10) # less than 10 words.
   text = (' '.join(Faker().words(words)) + '.').capitalize()
-  return random.choice([text, 'not applicable'])
+  
+  return random.choice([text, 'not applicable']), global_valid_data
 
 
 # biomaterial extracted
-def random_biomaterial_extracted():
+def random_biomaterial_extracted(invalid_data):
   """
   Generate Random Extracted Biomaterial
   
   return: string containing "biomaterial extracted" from CanCOGeN vocabulary.
           vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('biomaterial_extracted'))
+  return (random.choice(covid19_vocab_dict.get('biomaterial_extracted')),
+          global_valid_data)
 
 
 # host common name
-def random_host_common_name():
+def random_host_common_name(invalid_data):
   """
   Generate Random Host - Common Name
   
   return: string containing "host (common name)" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('host_common_name'))
+  return (random.choice(covid19_vocab_dict.get('host_common_name')),
+          global_valid_data)
 
 
 # host scientific name
-def random_host_scientific_name():
+def random_host_scientific_name(invalid_data):
   """
   Generate Random Host - Scientific Name
   
   return: string containing "host (scientific name)" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('host_scientific_name'))
+  return (random.choice(covid19_vocab_dict.get('host_scientific_name')),
+          global_valid_data)
 
 
 # host health state
-def random_host_health_state():
+def random_host_health_state(invalid_data):
   """
   Generate Random Host Health State
   
   return: string containing "host health state" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('host_health_state'))
+  return (random.choice(covid19_vocab_dict.get('host_health_state')),
+          global_valid_data)
 
 
 # host health status details
-def random_host_health_status_details():
+def random_host_health_status_details(invalid_data):
   """
   Generate Random Host Health Status Details
   
   return: string containing "host health status details" from CanCOGeN 
           vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('host_health_status_details'))
+  return (random.choice(covid19_vocab_dict.get('host_health_status_details')), 
+          global_valid_data)
 
 
 # host disease
-def random_host_disease():
+def random_host_disease(invalid_data):
   """
   Generate Random Host Disease
   
   return: string containing "host disease" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('host_disease'))
+  return (random.choice(covid19_vocab_dict.get('host_disease')), 
+          global_valid_data)
 
 
 # host age
@@ -531,21 +564,21 @@ def random_host_age(invalid_data):
     return random.choice([age_range, age_text]), 'age_error'
   
   # output valid date format.
-  return str(age), 'VALID'
+  return str(age), global_valid_data
 
 
 # host gender
-def random_host_gender():
+def random_host_gender(invalid_data):
   """
   Generate Random Host Gender
   
   return: string containing "host gender" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('host_gender'))
+  return random.choice(covid19_vocab_dict.get('host_gender')), global_valid_data
 
 
 # host subject ID
-def random_host_subject_id():
+def random_host_subject_id(invalid_data):
   """
   Generate Random Host Subject ID
   
@@ -559,28 +592,30 @@ def random_host_subject_id():
   if with_affix == True:
     affix = random.choice(['_','-','/','|',':',';','+'])
 
-  return prefix + affix + suffix
+  return (prefix + affix + suffix), global_valid_data
 
 
 # signs symptoms
-def random_signs_symptoms():
+def random_signs_symptoms(invalid_data):
   """
   Generate Random Signs/Symptoms
   
   return: string containing "signs and symptoms" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('signs_symptoms'))
+  return (random.choice(covid19_vocab_dict.get('signs_symptoms')), 
+          global_valid_data)
 
 
 # travel history
-def random_travel_history():
+def random_travel_history(invalid_data):
   """
   Generate Random Travel History
   
   return: string containing at least one hypothetical country and city, and up 
           to four additional countries (cities optional).
   """
-  locations = (str(random_country()) + ', ' + str(random_city()))
+  locations = (str(random_country(invalid_data)) + ', ' 
+               + str(random_city(invalid_data)))
 
   for i in range(random.randint(0,5)):
 
@@ -588,59 +623,63 @@ def random_travel_history():
 
     if with_city == True:
       # City known; currently only outputting Canadian cities, regardless of country.
-      locations = locations + str('; ' + str(random_country()) + ', ' + str(random_city()))
+      locations = locations + str('; ' + str(random_country(invalid_data)) 
+                                  + ', ' + str(random_city(invalid_data)))
     else:
       # City unknown.
-      locations = locations + str('; ' + str(random_country()))
+      locations = locations + str('; ' + str(random_country(invalid_data)))
 
-  return locations
+  return locations, global_valid_data
 
 
 # exposure event
-def random_exposure_event():
+def random_exposure_event(invalid_data):
   """
   Generate Random Exposure Event
   
   return: string containing "exposure event" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('exposure_event'))
+  return (random.choice(covid19_vocab_dict.get('exposure_event')), 
+          global_valid_data)
 
 
 # library_ID
-def random_library_id(specimen_collector_sample_id):
+def random_library_id(specimen_collector_sample_id, invalid_data):
   """
   Generate Random Sequencing Library ID
   
   return: string containing imitation user-defined "library ID".
   """
-  return (specimen_collector_sample_id
+  return ((specimen_collector_sample_id
           + random.choice(['_','-','/','|',':',';',' ']) 
-          + str(random.randint(0,9)))
+          + str(random.randint(0,9))), 
+          global_valid_data)
 
 
 # MinIon barcode
-def random_minIon_barcode():
+def random_minIon_barcode(invalid_data):
   """
   Generate Random minIon Barcode
   
   return: int representing imitation barcode of a MinIon sequencing unit.
   """
-  return random.randint(1000000000,10000000000)
+  return random.randint(1000000000,10000000000), global_valid_data
 
 
 # sequencing instrument
-def random_seq_instrument():
+def random_seq_instrument(invalid_data):
   """
   Generate Random Sequencing Instrument
   
   return: string containing "sequencing instrument" from CanCOGeN vocabulary.
   """
   choices = covid19_vocab_dict.get('sequencing_instrument')
-  return random.choice(choices)
+  
+  return random.choice(choices), global_valid_data
 
 
 # sequencing_protocol_source
-def random_seq_protocol_source():
+def random_seq_protocol_source(invalid_data):
   """
   Generate Random Sequencing Protocol Source Organization/Authors
   
@@ -651,10 +690,9 @@ def random_seq_protocol_source():
   version = random.choice([' v',' V',' v.',' V.',' v ',' V ',' v. ',' V. '])
   version_num = round(random.uniform(1,15), decimal)
 
-  return source + version + str(version_num)
+  return source + version + str(version_num), global_valid_data
 
 
-# seq_kit_number
 def random_alphanumeric():
   """
   Generate Random Alphanumeric
@@ -666,73 +704,84 @@ def random_alphanumeric():
                                      string.digits) for _ in 
                        range(random.randint(6,20))))
     
-  return random.choice([alpha_num,alpha_num.upper(),alpha_num.lower()])
+  return (random.choice([alpha_num,alpha_num.upper(),alpha_num.lower()]),
+          global_valid_data)
 
 
-def random_filename():
+# seq_kit_number
+def random_seq_kit_num(invalid_data):
+
+  return random_alphanumeric()
+
+def random_filename(invalid_data):
   """
   Generate Random Filename
   
   return: string containing imitation file name.
   """
   joiner = random.choice([' ','_','-'])
-  return joiner.join(Faker().words(random.randint(1,4)))
+  return joiner.join(Faker().words(random.randint(1,4))), global_valid_data
 
 
 # amplicon_pcr_primers_filename
-def random_txt_filename():
+def random_txt_filename(invalid_data):
   """
   Generate Random TXT Filename
   
   return: string containing imitation filename in ".txt" format.
   """
-  return random_filename() + '.txt'
+  # call random_filename, ignoring invalid_data information.
+  return (random_filename(invalid_data)[0] + '.txt'), global_valid_data
 
 
 # r1 fastq filename
 # r2 fastq filename
-def random_fastq_filename():
+def random_fastq_filename(invalid_data):
   """
   Generate Random FASTQ Filename
   
   return: string containing imitation filename in ".fastq.gz" format.
   """
-  return random_filename() + '.fastq.gz'
+  # call random_filename, ignoring invalid_data information.
+  return (random_filename(invalid_data)[0] + '.fastq.gz'), global_valid_data
 
 
 # fast5 filename
-def random_fast5_filename():
+def random_fast5_filename(invalid_data):
   """
   Generate Random FAST5 Filename
   
   return: string containing imitation filename in ".fast5" format.
   """
-  return random_filename() + '.fast5'
+  # call random_filename, ignoring invalid_data information.
+  return (random_filename(invalid_data)[0] + '.fast5'), global_valid_data
   
   
 # fasta filename
 # consensus sequence filename
-def random_fasta_filename():
+def random_fasta_filename(invalid_data):
   """
   Generate Random FASTA Filename
   
   return: string containing imitation filename in ".fasta" format.
   """
-  return random_filename() + '.fasta'
+  # call random_filename, ignoring invalid_data information.
+  return (random_filename(invalid_data)[0] + '.fasta'), global_valid_data
 
 
 # annotation feature table filename
-def random_feature_table_filename():
+def random_feature_table_filename(invalid_data):
   """
   Generate Random Feature Table Filename
   
   return: string containing imitation filename in ".tbl" format.
   """
-  return random_filename() + '.tbl'
+  # call random_filename, ignoring invalid_data information.
+  return (random_filename(invalid_data)[0] + '.tbl'), global_valid_data
 
 
 # raw sequence data processing
-def random_seq_process():
+def random_seq_process(invalid_data):
   """
   Generate Random Raw Sequence Data Process Name.
   
@@ -748,43 +797,44 @@ def random_seq_process():
   version_num = round(random.uniform(1,15), decimal) 
   suffix = version + str(random.randint(0,10)) + '.' + str(version_num)
 
-  return prefix + suffix
+  return (prefix + suffix), global_valid_data
 
 
 # sequence depth (average)
 # assembly coverage depth
-def random_seq_depth():
+def random_seq_depth(invalid_data):
   """
   Generate Random Average Sequencing Depth
   
   return: string containing random sequencing depth number.
   """
-  return str(random.randint(1,150)) + 'x'
+  return (str(random.randint(1,150)) + 'x'), global_valid_data
 
 
 # assembly name
-def random_assembly_name(specimen_collector_sample_id):
+def random_assembly_name(specimen_collector_sample_id, invalid_data):
   """
   Generate Random Sequence Assembly Name
   
   return: string containing imitation assembly name/version.
   """
   return (specimen_collector_sample_id.lower() + str(random.randint(0,100)) + 
-          'assembly.fasta')
+          'assembly.fasta'), global_valid_data
 
 
 # assembly software/method
-def random_assembly_software():
+def random_assembly_software(invalid_data):
   """
   Generate Random Assembly Software Name
   
   return: string containing "assembly software" from CanCOGeN vocabulary.
   """
-  return random.choice(covid19_vocab_dict.get('assembly_software'))
+  return (random.choice(covid19_vocab_dict.get('assembly_software')), 
+          global_valid_data)
 
 
 # assembly coverage breadth
-def random_assembly_coverage_breadth():
+def random_assembly_coverage_breadth(invalid_data):
   """
   Generate Random Assembly Coverage Breadth
   
@@ -792,7 +842,8 @@ def random_assembly_coverage_breadth():
   """
   decimal = random.choice([random.randint(1,2),None])
   value = random.choice([random.randint(1,101), round(random.uniform(1,101), decimal)])
-  return str(value) + '%'
+  
+  return (str(value) + '%'), global_valid_data
 
 
 # r1 fastq filepath
@@ -800,7 +851,7 @@ def random_assembly_coverage_breadth():
 # fast5 filepath
 # fasta filepath
 # consensus sequence filepath
-def random_filepath(filename):
+def random_filepath(filename, invalid_data):
   """
   Generate Random Filepath
   
@@ -836,12 +887,12 @@ def random_filepath(filename):
     filepath_list = [prefix, 'Users', username, folder_1, folder_2, filename]
 
     # Windows filepaths defaults to '\' but do work with '/'.
-    return '\\'.join(filepath_list).replace('\\\\','\\')
+    return '\\'.join(filepath_list).replace('\\\\','\\'), global_valid_data
 
   # User is using Mac OS.
   elif os == 'MacOS':
     filepath_list = ['/Users', username, folder_1, folder_2, filename]
-    return '/'.join(filepath_list).replace('//','/')
+    return '/'.join(filepath_list).replace('//','/'), global_valid_data
 
   # User is using Linux OS.
   else:
@@ -850,60 +901,60 @@ def random_filepath(filename):
     # at the beginning. 
     folder_2 = folder_2 + random.choice(['\\',';','&','"','.','#','$','-','*'])
     filepath_list = ['/Users', username, folder_1, folder_2, filename]
-    return '/'.join(filepath_list).replace('//','/')
+    return '/'.join(filepath_list).replace('//','/'), global_valid_data
 
 
 # number base pairs
-def random_bp_num():
+def random_bp_num(invalid_data):
   """
   Generate Random Base Pair Number
   
   return: int.
   """
-  return random.randint(30000,400000)
+  return random.randint(30000,400000), global_valid_data
 
 
 # consensus genome length
-def random_genome_length():
+def random_genome_length(invalid_data):
   """
   Generate Random Genome Length
   
   return: int.
   """
-  return random.randint(2500,35000)
+  return random.randint(2500,35000), global_valid_data
 
 
 # mean contig length
-def random_contig_length():
+def random_contig_length(invalid_data):
   """
   Generate Random Contig Length
   
   return: int.
   """
-  return random.randint(10,50000)
+  return random.randint(10,50000), global_valid_data
 
 
 # N50
-def random_n50():
+def random_n50(invalid_data):
   """
   Generate Random N50
   
   return: int.
   """
-  return round(random.randint(10,5000), 2)
+  return round(random.randint(10,5000), 2), global_valid_data
 
 # Ns per 100 kbp
-def random_ns_100kbp():
+def random_ns_100kbp(invalid_data):
   """
   Generate Random Ns per 100 kbp Value
   
   return: float, rounded to two decimal places.
   """
-  return round(random.uniform(0,1000), 2)
+  return round(random.uniform(0,1000), 2), global_valid_data
 
 
 # consensus sequence ID
-def random_consensus_seq_id():
+def random_consensus_seq_id(invalid_data):
   """
   Generate Random Consensus Sequence ID
   
@@ -914,11 +965,12 @@ def random_consensus_seq_id():
   alpha_num = (''.join(random.choice(string.ascii_uppercase + 
                                      string.ascii_lowercase + 
                                      string.digits) for _ in range(random.randint(3,3))))
-  return prefix + '_' + alpha_num.upper() + str(random.randint(100,1000))
+  return ((prefix + '_' + alpha_num.upper() + str(random.randint(100,1000))), 
+          global_valid_data)
 
 
 # consensus sequence method
-def random_consensus_seq_method():
+def random_consensus_seq_method(invalid_data):
   """
   Generate Consensus Sequence Method Name
   
@@ -930,11 +982,12 @@ def random_consensus_seq_method():
   version = random.choice([' v',' V',' v.',' V.',' v ',' V ',' v. ',' V. '])
   version_num = round(random.uniform(1,15), decimal)
 
-  return random.choice([source, Faker().word()]) + version + str(version_num)
+  return ((random.choice([source, Faker().word()]) + version + str(version_num)), 
+          global_valid_data)
 
 
 # bioinformatics protocol
-def bioinformatics_protocol():
+def bioinformatics_protocol(invalid_data):
   """
   Generate Random Bioinformatics Protcol Name
   
@@ -946,13 +999,14 @@ def bioinformatics_protocol():
                'a', 'Platoforms', 'using', 'reads', 'nanopore', 'protocol',
                'sampling', 'viral', 'concentration', 'Detection', 'assay', 
                'PCR']
-  return random.choice([fake_protocol(), 
-                        Faker().sentence(ext_word_list=word_list).capitalize()])
+  return (random.choice([fake_protocol(invalid_data)[0], # omit invalid_data error info.
+                         Faker().sentence(ext_word_list=word_list).capitalize()]),
+          global_valid_data)
 
 
 # gene name 1
 # gene name 2
-def random_gene():
+def random_gene(invalid_data):
   """
   Generate Random Gene Name
   
@@ -982,19 +1036,20 @@ def random_gene():
   affix_2 = random.choice(gene_names)
   suffix = random.choice([' gene', '-gene', ''])
 
-  return random.choice([orfs, prefix + orfs, prefix + 
-                        random.choice([affix_1, affix_2])]) + suffix
+  return ((random.choice([orfs, prefix + orfs, prefix + 
+                          random.choice([affix_1, affix_2])]) + suffix),
+          global_valid_data)
 
 
 # diagnostic_pcr_Ct_value 1
 # diagnostic_pcr_Ct_value 2
-def random_pcr_ct_val():
+def random_pcr_ct_val(invalid_data):
   """
   Generate Random PCR Ct Value
   
   return: string.
   """
-  return str(random.randint(1,40))
+  return str(random.randint(1,40)), global_valid_data
 
 
 def random_name():
@@ -1006,11 +1061,12 @@ def random_name():
   # localized Faker provider packages without accents.
   local_ascii_no_accents = ['ar_EG','bs_BA','en_AU','en_CA','en_GB',
                             'en_IN','en_NZ','en_US']
+  
   return Faker(local_ascii_no_accents).name()
 
 
 # authors
-def authors():
+def authors(invalid_data):
   """
   Generate Random Authors
   
@@ -1020,26 +1076,28 @@ def authors():
   num_authors = random.randint(1,11)
   for i in range(num_authors):
     list_authors.append(random_name())
-  return (', '.join(list_authors))
+    
+  return (', '.join(list_authors)), global_valid_data
 
 
 # specimen collector sample ID
 # IRIDA sample name
 # isolate
-def random_specimen_collector_sample_id(country, province_territory, city):
+def random_specimen_collector_sample_id(country, province_territory, city, 
+                                        invalid_data):
   """
   Generate Sample/Isolate ID
   
   return: string containing and immitation user-define sample ID.
   """
   opt1 = str(random.choice([country, province_territory, city, 
-                          random_environmental_site()]))
-  opt2 = str(random.choice([random_environmental_material(), 
-                         random_organism(), 
-                         random_collection_device()]))
+                          random_environmental_site(invalid_data)[0]])) # omit invalid_data error info.
+  opt2 = str(random.choice([random_environmental_material(invalid_data)[0], # omit invalid_data error info.
+                         random_organism(invalid_data)[0], # omit invalid_data error info.
+                         random_collection_device(invalid_data)[0]])) # omit invalid_data error info.
   opt3 = str(random.choice([random.randint(1,1000), 
-                            random_alphanumeric()[0:4]]))
+                            random_alphanumeric()[0:4]])) # omit invalid_data error info.
 
   joiner = random.choice(['_','-',''])
 
-  return joiner.join([opt1, opt2, str(opt3)]).replace(' ','')
+  return joiner.join([opt1, opt2, str(opt3)]).replace(' ',''), global_valid_data

--- a/main.py
+++ b/main.py
@@ -2,9 +2,9 @@
 """
 Generate COVID19 CanCOGen Metadata
 
-Version: 1.6
+Version: 1.7
 COVID-19 Vocab Version #39
-Date: 2020/06/10
+Date: 2020/06/11
 
 Python v 3.8.3
 
@@ -35,313 +35,401 @@ def make_row(invalid_data=[]):
 
   ### Database Identifiers ###
   
-  # specimen_collector_sample_id moved to "Dependent IDs"
-  phac_sample_id = lib.random_phac_id()
-  # irida_sample_name moved to "Dependent IDs"
-  umbrella_bioproject_accession = lib.umbrella_bioproject_accession()
-  bioproject_accession = lib.random_bioproject_accession()
-  biosample_accession = lib.random_biosample_accession()
-  sra_accession = lib.random_sra_accession()
-  genbank_accession = lib.random_genbank_accession()
-  gisaid_accession = lib.random_gisaid_accession()
+  # phac_sample_id, valid/invalid error-grid information.
+  phac_sample_id, phac_sample_id_error = lib.random_phac_id(invalid_data)
+  # umbrella_bioproject_accession, valid/invalid error-grid information.
+  ub_accession, ub_accession_error = lib.umbrella_bioproject_accession(invalid_data)
+  # bioproject_accession, valid/invalid error-grid information.
+  bp_accession, bp_accession_error = lib.random_bioproject_accession(invalid_data)
+  # biosample_accession, valid/invalid error-grid information.
+  bs_accession, bs_accession_error = lib.random_biosample_accession(invalid_data)
+  # sra_accession, valid/invalid error-grid information.
+  sra_accession, sra_accession_error = lib.random_sra_accession(invalid_data)
+  # genbank_accession, valid/invalid error-grid information.
+  gb_accession, gb_accession_error = lib.random_genbank_accession(invalid_data)
+  # gisaid_accession, valid/invalid error-grid information.
+  gisaid_accession, gisaid_accession_error = lib.random_gisaid_accession(invalid_data)
   
   ### Sample Collection and Processing ###
   
-  sample_collected_by = lib.random_agency()
-  sample_collector_contact_email = lib.random_email()
-  sample_collector_contact_address = lib.random_address()
-  sequence_submitter_contact_email = lib.random_email()
-  sequence_submitter_contact_address = lib.random_address()
-  sample_collection_date = lib.random_date()
-  sample_received_date = lib.random_date()
-  geo_loc_name_country = lib.random_country()
-  geo_loc_name_province_territory = lib.random_province_territory()
-  geo_loc_name_city = lib.random_city()
-  organism = lib.random_organism()
-  # isolate moved to "Dependent IDs"
-  purpose_of_sampling = lib.random_purpose_of_sampling()
-  anatomical_material = lib.random_anatomical_material()
-  anatomical_part = lib.random_anatomical_part()
-  body_product = lib.random_body_product()
-  environmental_material = lib.random_environmental_material()
-  environmental_site = lib.random_environmental_site()
-  collection_device = lib.random_collection_device()
-  collection_method = lib.random_collection_method()
-  collection_protocol = lib.fake_protocol()
-  specimen_processing = lib.random_specimen_processing()
-  lab_host = lib.random_lab_host()
-  passage_number = lib.random_passage_number()
-  passage_method = lib.passage_method_text()
-  biomaterial_extracted = lib.random_biomaterial_extracted()
+  # sample_collected_by, valid/invalid error-grid information.
+  samp_col_by, samp_col_by_error = lib.random_agency(invalid_data)
+  # sample_collector_contact_email, valid/invalid error-grid information.
+  samp_col_email, samp_col_email_error = lib.random_email(invalid_data)
+  # sample_collector_contact_address, valid/invalid error-grid information.
+  samp_col_address, samp_col_address_error = lib.random_address(invalid_data)
+  # sequence_submitter_contact_email, valid/invalid error-grid information.
+  seq_sub_email, seq_sub_email_error = lib.random_email(invalid_data)
+  # sequence_submitter_contact_address, valid/invalid error-grid information.
+  seq_sub_address, seq_sub_address_error = lib.random_address(invalid_data)
+  # sample_collection_date, valid/invalid error-grid information.
+  samp_col_date, samp_col_date_error = lib.random_date(invalid_data)
+  # sample_received_date, valid/invalid error-grid information.
+  samp_rec_date, samp_rec_date_error = lib.random_date(invalid_data)
+  # geo_loc_name_country, valid/invalid error-grid information.
+  geo_loc_country, geo_loc_country_error = lib.random_country(invalid_data)
+  # geo_loc_name_province_territory, valid/invalid error-grid information.
+  geo_loc_prov_ter, geo_loc_prov_ter_error = lib.random_province_territory(invalid_data)
+  # geo_loc_name_city, valid/invalid error-grid information.
+  geo_loc_city, geo_loc_city_error = lib.random_city(invalid_data)
+  # organism, valid/invalid error-grid information.
+  organism, organism_error = lib.random_organism(invalid_data)
+  # purpose_of_sampling, valid/invalid error-grid information.
+  p_o_sampling, p_o_sampling_error = lib.random_purpose_of_sampling(invalid_data)
+  # anatomical_material, valid/invalid error-grid information.
+  anat_material, anat_material_error = lib.random_anatomical_material(invalid_data)
+  # anatomical_part, valid/invalid error-grid information.
+  anat_part, anat_part_error = lib.random_anatomical_part(invalid_data)
+  # body_product, valid/invalid error-grid information.
+  body_product, body_product_error = lib.random_body_product(invalid_data)
+  # environmental_material, valid/invalid error-grid information.
+  envi_material, envi_material_error = lib.random_environmental_material(invalid_data)
+  # environmental_site, valid/invalid error-grid information.
+  envi_site, envi_site_error = lib.random_environmental_site(invalid_data)
+  # collection_device, valid/invalid error-grid information.
+  col_device, col_device_error = lib.random_collection_device(invalid_data)
+  # collection_method, valid/invalid error-grid information.
+  col_method, col_method_error = lib.random_collection_method(invalid_data)
+  # collection_protocol, valid/invalid error-grid information.
+  col_protocol, col_protocol_error = lib.fake_protocol(invalid_data)
+  # specimen_processing, valid/invalid error-grid information.
+  spec_process, spec_process_error = lib.random_specimen_processing(invalid_data)
+  # lab_host, valid/invalid error-grid information.
+  lab_host, lab_host_error = lib.random_lab_host(invalid_data)
+  # passage_number , valid/invalid error-grid information.
+  passage_num, passage_num_error = lib.random_passage_number(invalid_data)
+  # passage_method, valid/invalid error-grid information.
+  passage_method, passage_method_error = lib.passage_method_text(invalid_data)
+  # biomaterial_extracted, valid/invalid error-grid information.
+  biom_extract, biom_extract_error = lib.random_biomaterial_extracted(invalid_data)
   
   ### Host Information ###
   
-  host_common_name = lib.random_host_common_name()
-  host_scientific_name = lib.random_host_scientific_name()
-  host_health_state = lib.random_host_health_state()
-  host_health_status_details = lib.random_host_health_status_details()
-  host_disease = lib.random_host_disease()
+  # host_common_name, valid/invalid error-grid information.
+  host_com_name, host_com_name_error = lib.random_host_common_name(invalid_data)
+  # host_scientific_name, valid/invalid error-grid information.
+  host_sci_name, host_sci_name_error = lib.random_host_scientific_name(invalid_data)
+  # host_health_state, valid/invalid error-grid information.
+  host_health_state, host_health_state_error = lib.random_host_health_state(invalid_data)
+  # host_health_status_details, valid/invalid error-grid information.
+  host_health_status, host_health_status_error = lib.random_host_health_status_details(invalid_data)
+  # host_disease, valid/invalid error-grid information.
+  host_disease, host_disease_error = lib.random_host_disease(invalid_data)
+  # host_age, valid/invalid error-grid information.
   host_age, host_age_error = lib.random_host_age(invalid_data)
-  host_gender = lib.random_host_gender()
-  host_origin_geo_loc_name_country = lib.random_country()
-  host_subject_id = lib.random_host_subject_id()
-  symptom_onset_date = lib.random_date()
-  signs_and_symptoms = lib.random_signs_symptoms()
+  # host_gender, valid/invalid error-grid information.
+  host_gender, host_gender_error = lib.random_host_gender(invalid_data)
+  # host_origin_geo_loc_name_country, valid/invalid error-grid information.
+  host_loc_country, host_loc_country_error = lib.random_country(invalid_data)
+  # host_subject_id, valid/invalid error-grid information.
+  host_sub_id, host_sub_id_error = lib.random_host_subject_id(invalid_data)
+  # symptom_onset_date, valid/invalid error-grid information.
+  symp_onset_date, symp_onset_date_error = lib.random_date(invalid_data)
+  # signs_and_symptoms, valid/invalid error-grid information.
+  signs_symptoms, signs_symptoms_error = lib.random_signs_symptoms(invalid_data)
   
   ### Host Exposure Information ###
   
-  location_of_exposure_geo_loc_name_country = lib.random_country()
-  travel_history = lib.random_travel_history()
-  exposure_event = lib.random_exposure_event()
+  # location_of_exposure_geo_loc_name_country, valid/invalid error-grid information.
+  loc_exp_country, loc_exp_country_error = lib.random_country(invalid_data)
+  # travel_history, valid/invalid error-grid information.  
+  trav_history, trav_history_error = lib.random_travel_history(invalid_data)
+  # exposure_event, valid/invalid error-grid information.
+  exp_event, exp_event_error = lib.random_exposure_event(invalid_data)
   
   ### Sequencing ###
   
-  minion_barcode = lib.random_minIon_barcode()
-  sequencing_instrument = lib.random_seq_instrument()
-  sequencing_protocol_name = lib.fake_protocol()
-  sequencing_protocol_source = lib.random_seq_protocol_source()
-  sequencing_kit_number = lib.random_alphanumeric()
-  amplicon_pcr_primers_filename = lib.random_txt_filename()
+  # minion_barcode, valid/invalid error-grid information.
+  minion_barcode, minion_barcode_error = lib.random_minIon_barcode(invalid_data)
+  # sequencing_instrument, valid/invalid error-grid information.
+  seq_instrument, seq_instrument_error = lib.random_seq_instrument(invalid_data)
+  # sequencing_protocol_name, valid/invalid error-grid information.
+  seq_prot_name, seq_prot_name_error = lib.fake_protocol(invalid_data)
+  # sequencing_protocol_source, valid/invalid error-grid information.
+  seq_prot_source, seq_prot_source_error = lib.random_seq_protocol_source(invalid_data)
+  # sequencing_kit_number, valid/invalid error-grid information.
+  seq_kit_num, seq_kit_num_error = lib.random_seq_kit_num(invalid_data)
+  # amplicon_pcr_primers_filename, valid/invalid error-grid information.
+  amp_pcr_filename, amp_pcr_filename_error = lib.random_txt_filename(invalid_data)
   
   ### Bioinformatics and QC metrics ###
   
-  raw_sequence_data_processing = lib.random_seq_process()
-  sequencing_depth_average = lib.random_seq_depth()
-  # assembly_name moved to "Dependent IDs"
-  assembly_method = lib.random_assembly_software()
-  assembly_coverage_breadth = lib.random_assembly_coverage_breadth()
-  assembly_coverage_depth = lib.random_seq_depth()
-  r1_fastq_filename = lib.random_fastq_filename()
-  r2_fastq_filename = lib.random_fastq_filename()
-  r1_fastq_filepath = lib.random_filepath(r1_fastq_filename)
-  r2_fastq_filepath = lib.random_filepath(r2_fastq_filename)
-  fast5_filename = lib.random_fast5_filename()
-  fast5_filepath = lib.random_filepath(fast5_filename)
-  fasta_filename = lib.random_fasta_filename()
-  fasta_filepath = lib.random_filepath(fasta_filename)
-  number_base_pairs = lib.random_bp_num()
-  consensus_genome_length = lib.random_genome_length()
-  mean_contig_length = lib.random_contig_length()
-  n50 = lib.random_n50()
-  ns_per_100_kbp = lib.random_ns_100kbp()
-  reference_genome_accession = lib.random_ref_genome()
-  consensus_sequence_id = lib.random_consensus_seq_id()
-  consensus_sequence_method = lib.random_consensus_seq_method()
-  consensus_sequence_filename = lib.random_fasta_filename()
-  consensus_sequence_filepath = lib.random_filepath(consensus_sequence_filename)
-  annotation_feature_table_filename = lib.random_feature_table_filename()
-  bioinformatics_protocol = lib.bioinformatics_protocol()
+  # raw_sequence_data_processing, valid/invalid error-grid information.
+  raw_seq_process, raw_seq_process_error = lib.random_seq_process(invalid_data)
+  # sequencing_depth_average, valid/invalid error-grid information.
+  seq_depth_avg, seq_depth_avg_error = lib.random_seq_depth(invalid_data)
+  # assembly_method, valid/invalid error-grid information.
+  assemb_method, assemb_method_error = lib.random_assembly_software(invalid_data)
+  # assembly_coverage_breadth, valid/invalid error-grid information.
+  assemb_cov_breadth, assemb_cov_breadth_error = lib.random_assembly_coverage_breadth(invalid_data)
+  # assembly_coverage_depth, valid/invalid error-grid information.
+  assemb_cov_depth, assemb_cov_depth_error = lib.random_seq_depth(invalid_data)
+  # r1_fastq_filename, valid/invalid error-grid information.
+  r1_filename, r1_filename_error = lib.random_fastq_filename(invalid_data)
+  # r2_fastq_filename, valid/invalid error-grid information.
+  r2_filename, r2_filename_error = lib.random_fastq_filename(invalid_data)
+  # r1_fastq_filepath, valid/invalid error-grid information.
+  r1_filepath, r1_filepath_error = lib.random_filepath(r1_filename, invalid_data)
+  # r2_fastq_filepath, valid/invalid error-grid information.
+  r2_filepath, r2_filepath_error = lib.random_filepath(r2_filename, invalid_data)
+  # fast5_filename, valid/invalid error-grid information.
+  fast5_filename, fast5_filename_error = lib.random_fast5_filename(invalid_data)
+  # fast5_filepath, valid/invalid error-grid information.
+  fast5_filepath, fast5_filepath_error = lib.random_filepath(fast5_filename, invalid_data)
+  # fasta_filename, valid/invalid error-grid information.
+  fasta_filename, fasta_filename_error = lib.random_fasta_filename(invalid_data)
+  # fasta_filepath, valid/invalid error-grid information.
+  fasta_filepath, fasta_filepath_error = lib.random_filepath(fasta_filename, invalid_data)
+  # number_base_pairs, valid/invalid error-grid information.
+  num_bp, num_bp_error = lib.random_bp_num(invalid_data)
+  # consensus_genome_length, valid/invalid error-grid information.
+  cons_genome_len, cons_genome_len_error = lib.random_genome_length(invalid_data)
+  # mean_contig_length, valid/invalid error-grid information.
+  mean_contig_len, mean_contig_len_error = lib.random_contig_length(invalid_data)
+  # n50, valid/invalid error-grid information.
+  n50, n50_error = lib.random_n50(invalid_data)
+  # ns_per_100_kbp, valid/invalid error-grid information.
+  ns_100kbp, ns_100kbp_error = lib.random_ns_100kbp(invalid_data)
+  # reference_genome_accession, valid/invalid error-grid information.
+  ref_genome_accession, ref_genome_accession_error = lib.random_ref_genome(invalid_data)
+  # consensus_sequence_id, valid/invalid error-grid information.
+  cons_seq_id, cons_seq_id_error = lib.random_consensus_seq_id(invalid_data)
+  # consensus_sequence_method, valid/invalid error-grid information.
+  cons_seq_method, cons_seq_method_error = lib.random_consensus_seq_method(invalid_data)
+  # consensus_sequence_filename, valid/invalid error-grid information.
+  cons_seq_filename, cons_seq_filename_error = lib.random_fasta_filename(invalid_data)
+  # consensus_sequence_filepath, valid/invalid error-grid information.
+  cons_seq_filepath, cons_seq_filepath_error = lib.random_filepath(cons_seq_filename, invalid_data)
+  # annotation_feature_table_filename, valid/invalid error-grid information.
+  annot_table_filename, annot_table_filename_error = lib.random_feature_table_filename(invalid_data)
+  # bioinformatics_protocol, valid/invalid error-grid information.
+  biof_protocol, biof_protocol_error = lib.bioinformatics_protocol(invalid_data)
   
   ### Pathogen Diagnostic Testing ###
   
-  gene_name_1 = lib.random_gene()
-  diagnostic_pcr_protocol_1 = lib.fake_protocol()
-  diagnostic_pcr_ct_value_1 = lib.random_pcr_ct_val()
-  gene_name_2 = lib.random_gene()
-  diagnostic_pcr_protocol_2 = lib.fake_protocol()
-  diagnostic_pcr_ct_value_2 = lib.random_pcr_ct_val()
+  # gene_name_1, valid/invalid error-grid information.
+  gene_1, gene_1_error = lib.random_gene(invalid_data)
+  # diagnostic_pcr_protocol_1, valid/invalid error-grid information.
+  pcr_protocol_1, pcr_protocol_1_error = lib.fake_protocol(invalid_data)
+  # diagnostic_pcr_ct_value_1, valid/invalid error-grid information.
+  pcr_ct_1, pcr_ct_1_error = lib.random_pcr_ct_val(invalid_data)
+  # gene_name_2, valid/invalid error-grid information.
+  gene_2, gene_2_error = lib.random_gene(invalid_data)
+  # diagnostic_pcr_protocol_2, valid/invalid error-grid information.
+  pcr_protocol_2, pcr_protocol_2_error = lib.fake_protocol(invalid_data)
+  # diagnostic_pcr_ct_value_2, valid/invalid error-grid information.
+  pcr_ct_2, pcr_ct_2_error = lib.random_pcr_ct_val(invalid_data)
   
   ### Contributor Acknowledgement ###
   
-  authors = lib.authors()
+  # authors, valid/invalid error-grid information.
+  authors, authors_error = lib.authors(invalid_data)
   
   ### Dependent IDs ###
   
-  specimen_collector_sample_id = lib.random_specimen_collector_sample_id(
-                                 geo_loc_name_country, 
-                                 geo_loc_name_province_territory,
-                                 geo_loc_name_city)
-  irida_sample_name = specimen_collector_sample_id
-  sequence_submitted_by = sample_collected_by
-  library_id = lib.random_library_id(specimen_collector_sample_id)
-  isolate = specimen_collector_sample_id
-  assembly_name = lib.random_assembly_name(specimen_collector_sample_id)
+  # specimen_collector_sample_id.
+  spec_col_sample_id, spec_col_sample_id_error = lib.random_specimen_collector_sample_id(
+                                                            geo_loc_country, 
+                                                            geo_loc_prov_ter,
+                                                            geo_loc_city,
+                                                            invalid_data)
+  # irida_sample_name.
+  irida_sample_id = spec_col_sample_id
+  # sequence_submitted_by.
+  seq_sub_by = samp_col_by
+  # library_id, valid/invalid error-grid information.
+  library_id, library_id_error = lib.random_library_id(spec_col_sample_id, invalid_data)
+  # isolate.
+  isolate = spec_col_sample_id
+  # assembly_name, valid/invalid error-grid information.
+  assemb_name, assemb_name_error = lib.random_assembly_name(spec_col_sample_id, invalid_data)
 
-  cols = [specimen_collector_sample_id, 
-          phac_sample_id, 
-          irida_sample_name, 
-          umbrella_bioproject_accession, 
-          bioproject_accession, 
-          biosample_accession, 
-          sra_accession, 
-          genbank_accession, 
-          gisaid_accession, 
-          sample_collected_by, 
-          sample_collector_contact_email, 
-          sample_collector_contact_address, 
-          sequence_submitted_by, 
-          sequence_submitter_contact_email, 
-          sequence_submitter_contact_address, 
-          sample_collection_date, 
-          sample_received_date, 
-          geo_loc_name_country, 
-          geo_loc_name_province_territory, 
-          geo_loc_name_city, 
-          organism, 
-          isolate, 
-          purpose_of_sampling, 
-          anatomical_material, 
-          anatomical_part, 
-          body_product, 
-          environmental_material, 
-          environmental_site, 
-          collection_device, 
-          collection_method, 
-          collection_protocol, 
-          specimen_processing, 
-          lab_host, 
-          passage_number, 
-          passage_method, 
-          biomaterial_extracted, 
-          host_common_name, 
-          host_scientific_name, 
-          host_health_state, 
-          host_health_status_details, 
-          host_disease, 
-          host_age, 
-          host_gender, 
-          host_origin_geo_loc_name_country, 
-          host_subject_id, 
-          symptom_onset_date, 
-          signs_and_symptoms, 
-          location_of_exposure_geo_loc_name_country, 
-          travel_history, 
-          exposure_event, 
-          library_id, 
-          minion_barcode, 
-          sequencing_instrument, 
-          sequencing_protocol_name, 
-          sequencing_protocol_source, 
-          sequencing_kit_number, 
-          amplicon_pcr_primers_filename, 
-          raw_sequence_data_processing, 
-          sequencing_depth_average, 
-          assembly_name, 
-          assembly_method, 
-          assembly_coverage_breadth, 
-          assembly_coverage_depth, 
-          r1_fastq_filename, 
-          r2_fastq_filename, 
-          r1_fastq_filepath, 
-          r2_fastq_filepath, 
-          fast5_filename, 
-          fast5_filepath, 
-          fasta_filename, 
-          fasta_filepath, 
-          number_base_pairs, 
-          consensus_genome_length, 
-          mean_contig_length, 
-          n50, 
-          ns_per_100_kbp, 
-          reference_genome_accession, 
-          consensus_sequence_id, 
-          consensus_sequence_method, 
-          consensus_sequence_filename, 
-          consensus_sequence_filepath, 
-          annotation_feature_table_filename, 
-          bioinformatics_protocol, 
-          gene_name_1, 
-          diagnostic_pcr_protocol_1, 
-          diagnostic_pcr_ct_value_1, 
-          gene_name_2, 
-          diagnostic_pcr_protocol_2, 
-          diagnostic_pcr_ct_value_2, 
+  # Row of generated data organised by column.
+  cols = [spec_col_sample_id,
+          phac_sample_id,
+          irida_sample_id,
+          ub_accession,
+          bp_accession,
+          bs_accession,
+          sra_accession,
+          gb_accession,
+          gisaid_accession,
+          samp_col_by,
+          samp_col_email,
+          samp_col_address,
+          seq_sub_by,
+          seq_sub_email,
+          seq_sub_address,
+          samp_col_date,
+          samp_rec_date,
+          geo_loc_country,
+          geo_loc_prov_ter,
+          geo_loc_city,
+          organism,
+          isolate,
+          p_o_sampling,
+          anat_material,
+          anat_part,
+          body_product,
+          envi_material,
+          envi_site,
+          col_device,
+          col_method,
+          col_protocol,
+          spec_process,
+          lab_host,
+          passage_num,
+          passage_method,
+          biom_extract,
+          host_com_name,
+          host_sci_name,
+          host_health_state,
+          host_health_status,
+          host_disease,
+          host_age,
+          host_gender,
+          host_loc_country,
+          host_sub_id,
+          symp_onset_date,
+          signs_symptoms,
+          loc_exp_country,
+          trav_history,
+          exp_event,
+          library_id,
+          minion_barcode,
+          seq_instrument,
+          seq_prot_name,
+          seq_prot_source,
+          seq_kit_num,
+          amp_pcr_filename,
+          raw_seq_process,
+          seq_depth_avg,
+          assemb_name,
+          assemb_method,
+          assemb_cov_breadth,
+          assemb_cov_depth,
+          r1_filename,
+          r2_filename,
+          r1_filepath,
+          r2_filepath,
+          fast5_filename,
+          fast5_filepath,
+          fasta_filename,
+          fasta_filepath,
+          num_bp,
+          cons_genome_len,
+          mean_contig_len,
+          n50,
+          ns_100kbp,
+          ref_genome_accession,
+          cons_seq_id,
+          cons_seq_method,
+          cons_seq_filename,
+          cons_seq_filepath,
+          annot_table_filename,
+          biof_protocol,
+          gene_1,
+          pcr_protocol_1,
+          pcr_ct_1,
+          gene_2,
+          pcr_protocol_2,
+          pcr_ct_2,
           authors]
 
-  error_grid = [specimen_collector_sample_id, 
-          phac_sample_id, 
-          irida_sample_name, 
-          umbrella_bioproject_accession, 
-          bioproject_accession, 
-          biosample_accession, 
-          sra_accession, 
-          genbank_accession, 
-          gisaid_accession, 
-          sample_collected_by, 
-          sample_collector_contact_email, 
-          sample_collector_contact_address, 
-          sequence_submitted_by, 
-          sequence_submitter_contact_email, 
-          sequence_submitter_contact_address, 
-          sample_collection_date, 
-          sample_received_date, 
-          geo_loc_name_country, 
-          geo_loc_name_province_territory, 
-          geo_loc_name_city, 
-          organism, 
-          isolate, 
-          purpose_of_sampling, 
-          anatomical_material, 
-          anatomical_part, 
-          body_product, 
-          environmental_material, 
-          environmental_site, 
-          collection_device, 
-          collection_method, 
-          collection_protocol, 
-          specimen_processing, 
-          lab_host, 
-          passage_number, 
-          passage_method, 
-          biomaterial_extracted, 
-          host_common_name, 
-          host_scientific_name, 
-          host_health_state, 
-          host_health_status_details, 
-          host_disease, 
-          host_age_error, 
-          host_gender, 
-          host_origin_geo_loc_name_country, 
-          host_subject_id, 
-          symptom_onset_date, 
-          signs_and_symptoms, 
-          location_of_exposure_geo_loc_name_country, 
-          travel_history, 
-          exposure_event, 
-          library_id, 
-          minion_barcode, 
-          sequencing_instrument, 
-          sequencing_protocol_name, 
-          sequencing_protocol_source, 
-          sequencing_kit_number, 
-          amplicon_pcr_primers_filename, 
-          raw_sequence_data_processing, 
-          sequencing_depth_average, 
-          assembly_name, 
-          assembly_method, 
-          assembly_coverage_breadth, 
-          assembly_coverage_depth, 
-          r1_fastq_filename, 
-          r2_fastq_filename, 
-          r1_fastq_filepath, 
-          r2_fastq_filepath, 
-          fast5_filename, 
-          fast5_filepath, 
-          fasta_filename, 
-          fasta_filepath, 
-          number_base_pairs, 
-          consensus_genome_length, 
-          mean_contig_length, 
-          n50, 
-          ns_per_100_kbp, 
-          reference_genome_accession, 
-          consensus_sequence_id, 
-          consensus_sequence_method, 
-          consensus_sequence_filename, 
-          consensus_sequence_filepath, 
-          annotation_feature_table_filename, 
-          bioinformatics_protocol, 
-          gene_name_1, 
-          diagnostic_pcr_protocol_1, 
-          diagnostic_pcr_ct_value_1, 
-          gene_name_2, 
-          diagnostic_pcr_protocol_2, 
-          diagnostic_pcr_ct_value_2, 
-          authors]
+  # Error grid valid/invalid (error specific) information.
+  grid = ['-', # spec_col_sample_id_error placeholder
+          phac_sample_id_error,
+          '-', # irida_sample_id_error placeholder
+          ub_accession_error,
+          bp_accession_error,
+          bs_accession_error,
+          sra_accession_error,
+          gb_accession_error,
+          gisaid_accession_error,
+          samp_col_by_error,
+          samp_col_email_error,
+          samp_col_address_error,
+          '-', # seq_sub_by_error placeholder
+          seq_sub_email_error,
+          seq_sub_address_error,
+          samp_col_date_error,
+          samp_rec_date_error,
+          geo_loc_country_error,
+          geo_loc_prov_ter_error,
+          geo_loc_city_error,
+          organism_error,
+          '-', # isolate_error placeholder
+          p_o_sampling_error,
+          anat_material_error,
+          anat_part_error,
+          body_product_error,
+          envi_material_error,
+          envi_site_error,
+          col_device_error,
+          col_method_error,
+          col_protocol_error,
+          spec_process_error,
+          lab_host_error,
+          passage_num_error,
+          passage_method_error,
+          biom_extract_error,
+          host_com_name_error,
+          host_sci_name_error,
+          host_health_state_error,
+          host_health_status_error,
+          host_disease_error,
+          host_age_error,
+          host_gender_error,
+          host_loc_country_error,
+          host_sub_id_error,
+          symp_onset_date_error,
+          signs_symptoms_error,
+          loc_exp_country_error,
+          trav_history_error,
+          exp_event_error,
+          library_id_error,
+          minion_barcode_error,
+          seq_instrument_error,
+          seq_prot_name_error,
+          seq_prot_source_error,
+          seq_kit_num_error,
+          amp_pcr_filename_error,
+          raw_seq_process_error,
+          seq_depth_avg_error,
+          assemb_name_error,
+          assemb_method_error,
+          assemb_cov_breadth_error,
+          assemb_cov_depth_error,
+          r1_filename_error,
+          r2_filename_error,
+          r1_filepath_error,
+          r2_filepath_error,
+          fast5_filename_error,
+          fast5_filepath_error,
+          fasta_filename_error,
+          fasta_filepath_error,
+          num_bp_error,
+          cons_genome_len_error,
+          mean_contig_len_error,
+          n50_error,
+          ns_100kbp_error,
+          ref_genome_accession_error,
+          cons_seq_id_error,
+          cons_seq_method_error,
+          cons_seq_filename_error,
+          cons_seq_filepath_error,
+          annot_table_filename_error,
+          biof_protocol_error,
+          gene_1_error,
+          pcr_protocol_1_error,
+          pcr_ct_1_error,
+          gene_2_error,
+          pcr_protocol_2_error,
+          pcr_ct_2_error,
+          authors_error]
 
-
-  return cols, error_grid
-  #return cols, None
+  # return row of data for data file and row of data validity for error grid.
+  return cols, grid
 
 
 def check_file_name(file_name):
@@ -378,7 +466,7 @@ def check_file_name(file_name):
   return file_name
               
 
-def generate_data_files(file_name, rows, delimiter, invalid_data=[]):
+def generate_data_file(file_name, rows, delimiter, invalid_data=[]):
   """
   Generate Sample Metadata File
   
@@ -437,4 +525,4 @@ def generate_data_files(file_name, rows, delimiter, invalid_data=[]):
             error_df.to_csv(error_file_name, sep=',', index=False))
 
 # for running script from command line.
-#generate_data_files(argv[1], int(argv[2]), argv[3])
+generate_data_file(argv[1], int(argv[2]), argv[3])


### PR DESCRIPTION
Completed integration of error-grid. When generating sample data, an additional "error-grid" file will be generated that shows the data validity in a grid corresponding to the generated sample data cells. Valid data is indicated by '-' and invalid data indicated by the name of the error introduced.

Also renamed all CanCOGeN variables in main.py in improve readability. Included comments that show the full "CanCOGeN" metadata label associated with each new variable name.